### PR TITLE
Don't create a database in the Aurora stack

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -135,6 +135,7 @@ Resources:
         DBMasterUsername: postgres
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
+        DBName: ''
         DBPort: '5432'
         DBAllocatedStorageEncrypted: !Ref DBStorageEncrypted
         CustomDBSecurityGroup: !Ref DBSecurityGroup


### PR DESCRIPTION
The Aurora cloudformation template has a DBName parameter which will create a database after provisioning if it is supplied. It has a default value so we need to explicitly pass an empty string so that it does not create a database as this could be confusing for customers.