### PR TITLE
DCD-289: Linting - Remove unnecessary Mappings and DependsOn

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+templates:
+  - templates/*

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -122,44 +122,6 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
-Mappings:
-  AWSInfoRegionMap:
-    ap-northeast-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-northeast-2:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-south-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-southeast-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    ap-southeast-2:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    eu-central-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    eu-west-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    sa-east-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    us-east-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    us-gov-west-1:
-      Partition: aws-us-gov
-      QuickStartS3URL: https://s3-us-gov-west-1.amazonaws.com
-    us-west-1:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
-    us-west-2:
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
 Resources:
   VPCStack:
     Type: AWS::CloudFormation::Stack
@@ -185,8 +147,6 @@ Resources:
         VPCCIDR: !Ref 'VPCCIDR'
   BastionStack:
     Type: AWS::CloudFormation::Stack
-    DependsOn:
-      - VPCStack
     Properties:
       TemplateURL: !Sub
         - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}quickstarts/quickstart-bastion-for-atlassian-services.yaml


### PR DESCRIPTION
`cfn-lint` output:

```
W7001 Mapping 'AWSInfoRegionMap' is defined but not used
templates/quickstart-vpc-for-atlassian-services.yaml:126:3

W3005 Obsolete DependsOn on resource (VPCStack), dependency already enforced by a "Fn:GetAtt" at Resources/BastionStack/Properties/Parameters/Subnet/Fn::GetAtt/['VPCStack', 'Outputs', 'PublicSubnet1ID']
templates/quickstart-vpc-for-atlassian-services.yaml:189:9

W3005 Obsolete DependsOn on resource (VPCStack), dependency already enforced by a "Fn:GetAtt" at Resources/BastionStack/Properties/Parameters/VPC/Fn::GetAtt/['VPCStack', 'Outputs', 'VPCID']
templates/quickstart-vpc-for-atlassian-services.yaml:189:9
```