### PR TITLE
DCD-562: Fix duplicated DB identifier when using the same prefix

### DIFF
--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -172,7 +172,9 @@ Resources:
       AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       DBInstanceClass: !Ref DBInstanceClass
-      DBInstanceIdentifier: !Sub ["${RootStack}-db", RootStack: !Select [0, !Split ['-', !Ref 'AWS::StackName']]]
+      # In the next line of code the '-DB' delimeter is used to get the root stack name for database identifier
+      # 'AWS::StackName' produces MASTER_STACK_NAME-DB (as DB is the name of the nested stack resource).
+      DBInstanceIdentifier: !Sub ["${RootStack}-db", RootStack: !Select [0, !Split ['-DB', !Ref 'AWS::StackName']]]
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: postgres
       EngineVersion: '9.6'


### PR DESCRIPTION
Without this change, it wasn't possible to use stack names for example
`jira-8` and `jira-7` in the same time as database identifier was trimmed
to `jira` and that wasn't unique.

See https://github.com/atlassian/quickstart-atlassian-services/blob/develop/templates/quickstart-postgres-for-atlassian-services.yaml#L175