### PR TITLE
DCD-466: Fix NAT type

### DIFF
--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -3,37 +3,24 @@ global:
   owner: quickstart-eng@amazon.com
   qsname: quickstart-atlassian-services
   regions:
-    - ap-northeast-1
-    - ap-northeast-2
-    - ap-south-1
-    - ap-southeast-1
-    - ap-southeast-2
-    - eu-central-1
-    - eu-west-1
-    - sa-east-1
-    - us-east-1
-    - us-west-1
     - us-west-2
+    - ap-south-1
+    - eu-west-1
+    - us-east-1
+    - ca-central-1
+    - ap-northeast-1
+    - ap-southeast-2
+    - ap-southeast-1
+    - ap-northeast-2
+    - us-east-2
+    - eu-west-2
+    - eu-central-1
+    - us-west-1
+    - sa-east-1
+    - eu-west-3
   reporting: true
 
 tests:
   atlassian-vpc:
     parameter_input: quickstat-vpc-for-atlassian-services-inputs.json
     template_file: quickstart-vpc-for-atlassian-services.yaml
-    regions:
-      - us-west-2
-      - ap-south-1
-      - eu-west-1 
-      - us-east-1
-      - ca-central-1
-      - ap-northeast-1
-      - ap-southeast-2
-      - ap-southeast-1
-      - ap-northeast-2
-      - us-east-2
-      - eu-west-2
-      - eu-central-1
-      - us-west-1
-      - sa-east-1
-      - eu-west-3
-

--- a/templates/quickstart-bastion-for-atlassian-services.yaml
+++ b/templates/quickstart-bastion-for-atlassian-services.yaml
@@ -52,7 +52,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref LatestAmiId
-      InstanceType: t2.micro
+      InstanceType: t3.micro
       KeyName: !Ref KeyName
       NetworkInterfaces:
         - AssociatePublicIpAddress: true

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -131,7 +131,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+      Each Atlassian Standard Infrastructure (ASI) uses a unique identifier. If you have multiple ASIs within the same AWS region, use this field to specify where to deploy the DB.
     Type: String
 
 Conditions:

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -31,7 +31,7 @@ Metadata:
       AvailabilityZones:
         default: Availability Zones
       ExportPrefix:
-        default: Export variable prefix
+        default: ASI identifier
       KeyPairName:
         default: Key Name
       NATInstanceType:
@@ -61,7 +61,7 @@ Parameters:
     Type: List<AWS::EC2::AvailabilityZone::Name>
   ExportPrefix:
     Default: ATL-
-    Description: Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS
+    Description: Identifier used in all variables exported from this deployment’s Atlassian Standard Infrastructure (VPCID, SubnetIDs, KeyName). Use different identifier to deploy multiple Atlassian Standard Infrastructures in the same AWS region.
       Quickstarts.
     Type: String
   KeyPairName:

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -69,8 +69,13 @@ Parameters:
       after it launches
     Type: AWS::EC2::KeyPair::KeyName
   NATInstanceType:
-    Default: t2.small
+    Default: t3.small
     AllowedValues:
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
       - t2.nano
       - t2.micro
       - t2.small
@@ -157,7 +162,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}quickstarts/quickstart-bastion-for-atlassian-services.yaml
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/quickstart-bastion-for-atlassian-services.yaml
         - QSS3Region: !If
             - GovCloudCondition
             - s3-us-gov-west-1


### PR DESCRIPTION
* `t2` family is not supported in some of the regions and caused taskcat to fail, I have switched the default to `t3.micro` and verified it is accessible in all regions
* I've also moved bastion template from `quickstarts` folder to `templates` (and deleted `quickstarts`)