### PR TITLE
DCD-858: Fix incorrect casing of vpcid param in database template

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -175,8 +175,7 @@ Resources:
           - !Split
             - ","
             - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
-        # NB: The VPCID is not used by the aurora template but it will fail if it is not provided.
-        VpcId:
+        VPCID:
           Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
 
   PostgresDatabase:


### PR DESCRIPTION
Somehow the case of the VPC ID param became incorrect.

See correct casing here: https://github.com/aws-quickstart/quickstart-amazon-aurora-postgresql/blob/1d9ccb7cde8c3b7d105cd1ad5d0202fe62134f65/templates/aurora_postgres.template.yaml#L246