### PR TITLE
DCD-954: Export the bastion host private IP address

### DIFF
--- a/templates/quickstart-bastion-for-atlassian-services.yaml
+++ b/templates/quickstart-bastion-for-atlassian-services.yaml
@@ -81,3 +81,6 @@ Outputs:
   BastionPubIp:
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt Bastion.PublicIp
+  BastionPrivateIp:
+    Description: The Private IP of the Bastion within the VPC
+    Value: !GetAtt Bastion.PrivateIp

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -207,6 +207,8 @@ Outputs:
   BastionPubIp:
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt 'BastionStack.Outputs.BastionPubIp'
+    Export:
+      Name: !Sub '${ExportPrefix}BastionIp'
   NatGatewayIP1:
     Description: Public IP for NAT gateway in Private Subnet 1
     Value: !GetAtt VPCStack.Outputs.NAT1EIP

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -207,8 +207,11 @@ Outputs:
   BastionPubIp:
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt 'BastionStack.Outputs.BastionPubIp'
+  BastionPrivIp:
+    Description: The Private IP of the Bastion within the VPC
+    Value: !GetAtt 'BastionStack.Outputs.BastionPrivateIp'
     Export:
-      Name: !Sub '${ExportPrefix}BastionIp'
+      Name: !Sub '${ExportPrefix}BastionPrivIp'
   NatGatewayIP1:
     Description: Public IP for NAT gateway in Private Subnet 1
     Value: !GetAtt VPCStack.Outputs.NAT1EIP


### PR DESCRIPTION
If `CidrBlock` was set in the product's the security group, the bastion host would not be able to ssh into the webserver. We export the ASI's bastion private IP so that the application stacks can import it and add the rule to their security group