### PR TITLE
Fix intermittent postgres stack failure

### DIFF
--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -189,7 +189,7 @@ Resources:
           def lambda_handler(event, context):
             stack_name = event['ResourceProperties']['StackName']
             responseData = {}
-            responseData['DBInstanceName'] = stack_name[:57] + "-db"
+            responseData['DBInstanceName'] = stack_name[:57].replace('-','') + "-db"
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
   DBNameGeneratorExecutionRole:
     Type: "AWS::IAM::Role"


### PR DESCRIPTION
On occasion the following error is encountered when the postgres stack is booted:

`The parameter Filter: db-instance-id is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens. (Service: AmazonRDS; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 46b3e558-0fd4-436f-bc9b-c8fbaf33943b)`

See: https://server-syd-bamboo.internal.atlassian.com/build/result/viewBuildLog.action?buildKey=DCD-AWSCROWD-DEPLOYHTTPS&buildNumber=19

Turns out whats happening is we are hitting the `double hyphen` constraint. This fix is to address that problem