### PR TITLE
DCD-948: Make Bastion host provisioning optional

### DIFF
--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -37,7 +37,7 @@ Metadata:
       ExportPrefix:
         default: ASI identifier
       KeyPairName:
-        default: Key Name
+        default: SSH Key Pair Name
       BastionHostRequired:
         default: Deploy Bastion host
       NATInstanceType:
@@ -204,6 +204,12 @@ Resources:
         VPC: !GetAtt VPCStack.Outputs.VPCID
 
 Outputs:
+  DefaultKey:
+    Condition: KeyProvided
+    Description: Default Ec2 keypair name
+    Value: !Ref 'KeyPairName'
+    Export:
+      Name: !Sub '${ExportPrefix}DefaultKey'
   PrivateSubnets:
     Description: A list of 2 Private subnets
     Value: !Join [ ',', [ !GetAtt VPCStack.Outputs.PrivateSubnet1AID, !GetAtt VPCStack.Outputs.PrivateSubnet2AID ]]

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -15,6 +15,10 @@ Metadata:
           - PublicSubnet2CIDR
           - VPCCIDR
       - Label:
+          default: Bastion host provisioning
+        Parameters:
+          - BastionHostRequired
+      - Label:
           default: Amazon EC2 Configuration
         Parameters:
           - KeyPairName
@@ -34,6 +38,8 @@ Metadata:
         default: ASI identifier
       KeyPairName:
         default: Key Name
+      BastionHostRequired:
+        default: Enable Bastion host deployment
       NATInstanceType:
         default: NAT Instance Type
       PrivateSubnet1CIDR:
@@ -57,7 +63,7 @@ Parameters:
     Description: CIDR block allowed to access Atlassian Services. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
     Type: String
   AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: You must specify 2 AZs here; 
+    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: You must specify 2 AZs here;
       if more are specified only the first 2 will be used.'
     Type: List<AWS::EC2::AvailabilityZone::Name>
   ExportPrefix:
@@ -68,7 +74,15 @@ Parameters:
   KeyPairName:
     Description: Public/private key pairs allow you to securely connect to your instance
       after it launches
-    Type: AWS::EC2::KeyPair::KeyName
+    Type: String
+    Default: ''
+  BastionHostRequired:
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to provision a Bastion host instance. (if true then an SSH Key Pair must be provided)
+    Type: String
   NATInstanceType:
     Default: t3.small
     AllowedValues:
@@ -137,6 +151,13 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
+  UseBastionHost:
+    !Equals [!Ref BastionHostRequired, true]
+  KeyProvided:
+    !Not [!Equals [!Ref KeyPairName, '']]
+  ProvisionBastion: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
 
 Resources:
   VPCStack:
@@ -170,6 +191,7 @@ Resources:
 
   BastionStack:
     Type: AWS::CloudFormation::Stack
+    Condition: ProvisionBastion
     Properties:
       TemplateURL: !Sub
         - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/quickstart-bastion-for-atlassian-services.yaml
@@ -184,11 +206,6 @@ Resources:
         VPC: !GetAtt VPCStack.Outputs.VPCID
 
 Outputs:
-  DefaultKey:
-    Description: Default Ec2 keypair name
-    Value: !Ref 'KeyPairName'
-    Export:
-      Name: !Sub '${ExportPrefix}DefaultKey'
   PrivateSubnets:
     Description: A list of 2 Private subnets
     Value: !Join [ ',', [ !GetAtt VPCStack.Outputs.PrivateSubnet1AID, !GetAtt VPCStack.Outputs.PrivateSubnet2AID ]]
@@ -205,9 +222,11 @@ Outputs:
     Export:
       Name: !Sub '${ExportPrefix}VPCID'
   BastionPubIp:
+    Condition: ProvisionBastion
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt 'BastionStack.Outputs.BastionPubIp'
   BastionPrivIp:
+    Condition: ProvisionBastion
     Description: The Private IP of the Bastion within the VPC
     Value: !GetAtt 'BastionStack.Outputs.BastionPrivateIp'
     Export:

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -150,11 +150,11 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
-  KeyProvided:
+  KeyPairProvided:
     !Not [!Equals [!Ref KeyPairName, '']]
   ProvisionBastion: !And
     - !Equals [!Ref BastionHostRequired, true]
-    - !Condition KeyProvided
+    - !Condition KeyPairProvided
 
 Resources:
   VPCStack:
@@ -204,7 +204,7 @@ Resources:
 
 Outputs:
   DefaultKey:
-    Condition: KeyProvided
+    Condition: KeyPairProvided
     Description: Default EC2 keypair name
     Value: !Ref 'KeyPairName'
     Export:

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -151,8 +151,6 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
-  UseBastionHost:
-    !Equals [!Ref BastionHostRequired, true]
   KeyProvided:
     !Not [!Equals [!Ref KeyPairName, '']]
   ProvisionBastion: !And

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -18,10 +18,10 @@ Metadata:
           default: Bastion host provisioning
         Parameters:
           - BastionHostRequired
+          - KeyPairName
       - Label:
           default: Amazon EC2 Configuration
         Parameters:
-          - KeyPairName
           - NATInstanceType
       - Label:
           default: AWS Quick Start Configuration
@@ -72,8 +72,7 @@ Parameters:
       Quickstarts.
     Type: String
   KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance
-      after it launches
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
     Type: String
     Default: ''
   BastionHostRequired:
@@ -81,7 +80,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Whether to provision a Bastion host instance; if 'true', then you need to provide an SSH Key Pair
+    Description: Whether to provision a Bastion host instance; if 'true', then you need to provide an EC2 Key Pair
     Type: String
   NATInstanceType:
     Default: t3.small

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -39,7 +39,7 @@ Metadata:
       KeyPairName:
         default: Key Name
       BastionHostRequired:
-        default: Enable Bastion host deployment
+        default: Deploy Bastion host
       NATInstanceType:
         default: NAT Instance Type
       PrivateSubnet1CIDR:
@@ -81,7 +81,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Whether to provision a Bastion host instance. (if true then an SSH Key Pair must be provided)
+    Description: Whether to provision a Bastion host instance; if 'true', then you need to provide an SSH Key Pair
     Type: String
   NATInstanceType:
     Default: t3.small

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -63,7 +63,7 @@ Parameters:
     Description: CIDR block allowed to access Atlassian Services. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
     Type: String
   AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: You must specify 2 AZs here;
+    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: You must specify 2 AZs here; 
       if more are specified only the first 2 will be used.'
     Type: List<AWS::EC2::AvailabilityZone::Name>
   ExportPrefix:

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -206,7 +206,7 @@ Resources:
 Outputs:
   DefaultKey:
     Condition: KeyProvided
-    Description: Default Ec2 keypair name
+    Description: Default EC2 keypair name
     Value: !Ref 'KeyPairName'
     Export:
       Name: !Sub '${ExportPrefix}DefaultKey'

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -77,7 +77,7 @@ Parameters:
     Type: String
     Default: ''
   BastionHostRequired:
-    Default: "false"
+    Default: "true"
     AllowedValues:
       - "true"
       - "false"


### PR DESCRIPTION
⚠️ **DO NOT MERGE UNTIL DOCUMENTATION IS READY**:warning:

[Documentation ticket](https://bulldog.internal.atlassian.com/browse/DCD-994)

Proposed changes for making Bastion host provisioning/usage optional. See associated PR for Crowd template changes:

https://github.com/atlassian/quickstart-atlassian-crowd/pull/26

What changes look and read like when rendered:

**templates/quickstart-vpc-for-atlassian-services.yaml**
![image](https://user-images.githubusercontent.com/409063/81266202-b7642600-9087-11ea-8a1c-62b4cf9e7a51.png)

**Passing CI on branch CI**
https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSSERVICES16-1

Additional details on how existing clusters will now work with this optional behavior going forward here:
https://hello.atlassian.net/wiki/spaces/~560412609/pages/719468588/DC+AWS+QuickStart+-+Making+Bastions+optional