### PR TITLE
DCD-1051: Refactor code

### DIFF
--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -138,9 +138,6 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
 
 Conditions:
-  GovCloudCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
   DBProvisionedIops:
     !Equals [!Ref DBStorageType, io1]
   UseDatabaseEncryption:
@@ -167,8 +164,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: !Sub
-                - arn:${ArnPartition}:iam::${AWS::AccountId}:root
-                - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
+                - arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action: 'kms:*'
             Resource: '*'
       Tags:
@@ -227,8 +223,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource: !Sub
-              - arn:${ArnPartition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*
-              - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
+              - arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*
   DB:
     Type: AWS::RDS::DBInstance
     Properties:


### PR DESCRIPTION
Simplifying this code

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

> AWS::Partition
> Returns the partition that the resource is in. For standard AWS regions, the partition is aws. For resources in other > partitions, the partition is aws-partitionname. For example, the partition for resources in the China (Beijing and Ningxia) > region is aws-cn and the partition for resources in the AWS GovCloud (US-West) region is aws-us-gov. 