### PR TITLE
NONE: Add postgres 12 to allowed values for DB engine version

### DIFF
--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -18,6 +18,7 @@ Parameters:
       - 9
       - 10
       - 11
+      - 12
     Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
     Type: String
   DBSecurityGroup:


### PR DESCRIPTION
Postgres 12 was not an option for the database template but it was the default option for Bitbucket cloudformation template which caused builds to fail. I've added the option now.