### PR TITLE
Dcd 1294 security fix quickstart services

### DIFF
--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -264,7 +264,6 @@ Resources:
         - Key: "atl:quickstart:timestamp"
           Value: "TIMESTAMP: 2021-02-12T01:35:01Z"
       VPCSecurityGroups: [!Ref CustomDBSecurityGroup]
-      PubliclyAccessible: false
     
 Outputs:
   RDSEndPointAddress:

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -171,6 +171,7 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub ["${StackName} Encryption Key", StackName: !Ref 'AWS::StackName']
+      EnableKeyRotation: true
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption
     Type: AWS::KMS::Alias
@@ -263,6 +264,7 @@ Resources:
         - Key: "atl:quickstart:timestamp"
           Value: "TIMESTAMP: 2021-02-12T01:35:01Z"
       VPCSecurityGroups: [!Ref CustomDBSecurityGroup]
+      PubliclyAccessible: false
     
 Outputs:
   RDSEndPointAddress:


### PR DESCRIPTION
Enabled key rotation got KMS and blocked public access to DB Instances