### PR TITLE
DCD-1316: Update SSH key name description

### DIFF
--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -71,7 +71,7 @@ Parameters:
       Quickstarts.
     Type: String
   KeyPairName:
-    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
+    Description: Public/private EC2 Key Pairs (without file extension) to allow you to securely access the Bastion host.
     Type: String
     Default: ''
   BastionHostRequired:


### PR DESCRIPTION
Description of the 'key Pairs Name SSH' field modified to reduce the confusion during Quickstart set up.