### PR TITLE
DCD-1349: asi cfn lint fix

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -9,3 +9,20 @@ ignore_checks:
   - E3012
   # E1001: Top level template section tests is not valid
   - E1001
+  # E9101: "master" may be interpreted as a biased term. Consider a more inclusive alternative, such as "primary", "main", or "leader"
+  - E9101
+  # W9006: Parameter Group name contains spelling error(s)
+  # W9006: Parameter Group name is not sentence case
+  # W9006: Parameter Label is not sentence case
+  # W9006: Parameter Label contains spelling error(s)
+  - W9006
+  # W9002: Parameter is missing ParameterLabel
+  - W9002
+  # W9003: Parameter is not in a ParameterGroup
+  - W9003
+  # ERDSDBInstancePubliclyAccessible: AWS::RDS::DBInstance must have PubliclyAccessible configured False
+  - ERDSDBInstancePubliclyAccessible
+  # EIAMPolicyWildcardResource: IAM policy should not allow * resource; This method in this in this policy support granular permissions
+  - EIAMPolicyWildcardResource
+  # ERDSStorageEncryptionEnabled AWS::RDS::DBCluster must have StorageEncryption enabled
+  - ERDSStorageEncryptionEnabled

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -353,56 +353,56 @@ Resources:
               AWS:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
             Action:
-            - kms:GetKeyPolicy
-            - kms:UpdateKeyDescription
+            - kms:CancelKeyDeletion
+            - kms:ConnectCustomKeyStore
+            - kms:CreateAlias
+            - kms:CreateCustomKeyStore
+            - kms:CreateGrant
+            - kms:CreateKey
             - kms:Decrypt
+            - kms:DeleteAlias
+            - kms:DeleteCustomKeyStore
+            - kms:DeleteImportedKeyMaterial
+            - kms:DescribeCustomKeyStores
+            - kms:DescribeKey
+            - kms:DisableKey
+            - kms:DisableKeyRotation
+            - kms:DisconnectCustomKeyStore
             - kms:EnableKey
             - kms:EnableKeyRotation
-            - kms:GenerateDataKeyPair
-            - kms:DescribeKey
-            - kms:ReEncryptFrom
-            - kms:DeleteAlias
-            - kms:ImportKeyMaterial
-            - kms:CancelKeyDeletion
-            - kms:DisconnectCustomKeyStore
-            - kms:DeleteCustomKeyStore
-            - kms:ListKeyPolicies
-            - kms:ListResourceTags
-            - kms:GenerateDataKeyWithoutPlaintext
-            - kms:CreateCustomKeyStore
-            - kms:GetParametersForImport
-            - kms:ListAliases
-            - kms:ListRetirableGrants
-            - kms:GenerateRandom
             - kms:Encrypt
-            - kms:DisableKeyRotation
-            - kms:UpdateCustomKeyStore
-            - kms:RetireGrant
-            - kms:ReEncryptTo
-            - kms:UpdatePrimaryRegion
+            - kms:GenerateDataKey
+            - kms:GenerateDataKeyPair
             - kms:GenerateDataKeyPairWithoutPlaintext
-            - kms:ReplicateKey
+            - kms:GenerateDataKeyWithoutPlaintext
+            - kms:GenerateRandom
+            - kms:GetKeyPolicy
             - kms:GetKeyRotationStatus
+            - kms:GetParametersForImport
+            - kms:GetPublicKey
+            - kms:ImportKeyMaterial
+            - kms:ListAliases
+            - kms:ListGrants
+            - kms:ListKeyPolicies
+            - kms:ListKeys
+            - kms:ListResourceTags
+            - kms:ListRetirableGrants
+            - kms:PutKeyPolicy
+            - kms:ReEncryptFrom
+            - kms:ReEncryptTo
+            - kms:ReplicateKey
+            - kms:RetireGrant
+            - kms:RevokeGrant
+            - kms:ScheduleKeyDeletion
+            - kms:Sign
+            - kms:SynchronizeMultiRegionKey
             - kms:TagResource
             - kms:UntagResource
-            - kms:RevokeGrant
-            - kms:CreateKey
-            - kms:SynchronizeMultiRegionKey
-            - kms:ScheduleKeyDeletion
             - kms:UpdateAlias
-            - kms:Sign
-            - kms:DescribeCustomKeyStores
-            - kms:ConnectCustomKeyStore
-            - kms:DisableKey
-            - kms:CreateAlias
-            - kms:GetPublicKey
-            - kms:PutKeyPolicy
+            - kms:UpdateCustomKeyStore
+            - kms:UpdateKeyDescription
+            - kms:UpdatePrimaryRegion
             - kms:Verify
-            - kms:GenerateDataKey
-            - kms:CreateGrant
-            - kms:ListKeys
-            - kms:ListGrants
-            - kms:DeleteImportedKeyMaterial
             Resource: '*'
       Tags:
         - Key: Name

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -357,6 +357,7 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName
+    EnableKeyRotation: true
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption
     Type: AWS::KMS::Alias

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -352,12 +352,62 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
-            Action: 'kms:*'
+            Action:
+            - kms:GetKeyPolicy
+            - kms:UpdateKeyDescription
+            - kms:Decrypt
+            - kms:EnableKey
+            - kms:EnableKeyRotation
+            - kms:GenerateDataKeyPair
+            - kms:DescribeKey
+            - kms:ReEncryptFrom
+            - kms:DeleteAlias
+            - kms:ImportKeyMaterial
+            - kms:CancelKeyDeletion
+            - kms:DisconnectCustomKeyStore
+            - kms:DeleteCustomKeyStore
+            - kms:ListKeyPolicies
+            - kms:ListResourceTags
+            - kms:GenerateDataKeyWithoutPlaintext
+            - kms:CreateCustomKeyStore
+            - kms:GetParametersForImport
+            - kms:ListAliases
+            - kms:ListRetirableGrants
+            - kms:GenerateRandom
+            - kms:Encrypt
+            - kms:DisableKeyRotation
+            - kms:UpdateCustomKeyStore
+            - kms:RetireGrant
+            - kms:ReEncryptTo
+            - kms:UpdatePrimaryRegion
+            - kms:GenerateDataKeyPairWithoutPlaintext
+            - kms:ReplicateKey
+            - kms:GetKeyRotationStatus
+            - kms:TagResource
+            - kms:UntagResource
+            - kms:RevokeGrant
+            - kms:CreateKey
+            - kms:SynchronizeMultiRegionKey
+            - kms:ScheduleKeyDeletion
+            - kms:UpdateAlias
+            - kms:Sign
+            - kms:DescribeCustomKeyStores
+            - kms:ConnectCustomKeyStore
+            - kms:DisableKey
+            - kms:CreateAlias
+            - kms:GetPublicKey
+            - kms:PutKeyPolicy
+            - kms:Verify
+            - kms:GenerateDataKey
+            - kms:CreateGrant
+            - kms:ListKeys
+            - kms:ListGrants
+            - kms:DeleteImportedKeyMaterial
             Resource: '*'
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName
-    EnableKeyRotation: true
+      EnableKeyRotation: true
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption
     Type: AWS::KMS::Alias
@@ -473,7 +523,7 @@ Resources:
         log_rotation_size: '102400'
         # The following are recommended to assist security scanning.
         log_statement: "ddl"
-        log_min_duration_statement: 15000
+        log_min_duration_statement: "15000"
 
   RDSDBClusterParameterGroup:
     Type: AWS::RDS::DBClusterParameterGroup

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -166,7 +166,57 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
-            Action: 'kms:*'
+            Action:
+              - kms:GetKeyPolicy
+              - kms:UpdateKeyDescription
+              - kms:Decrypt
+              - kms:EnableKey
+              - kms:EnableKeyRotation
+              - kms:GenerateDataKeyPair
+              - kms:DescribeKey
+              - kms:ReEncryptFrom
+              - kms:DeleteAlias
+              - kms:ImportKeyMaterial
+              - kms:CancelKeyDeletion
+              - kms:DisconnectCustomKeyStore
+              - kms:DeleteCustomKeyStore
+              - kms:ListKeyPolicies
+              - kms:ListResourceTags
+              - kms:GenerateDataKeyWithoutPlaintext
+              - kms:CreateCustomKeyStore
+              - kms:GetParametersForImport
+              - kms:ListAliases
+              - kms:ListRetirableGrants
+              - kms:GenerateRandom
+              - kms:Encrypt
+              - kms:DisableKeyRotation
+              - kms:UpdateCustomKeyStore
+              - kms:RetireGrant
+              - kms:ReEncryptTo
+              - kms:UpdatePrimaryRegion
+              - kms:GenerateDataKeyPairWithoutPlaintext
+              - kms:ReplicateKey
+              - kms:GetKeyRotationStatus
+              - kms:TagResource
+              - kms:UntagResource
+              - kms:RevokeGrant
+              - kms:CreateKey
+              - kms:SynchronizeMultiRegionKey
+              - kms:ScheduleKeyDeletion
+              - kms:UpdateAlias
+              - kms:Sign
+              - kms:DescribeCustomKeyStores
+              - kms:ConnectCustomKeyStore
+              - kms:DisableKey
+              - kms:CreateAlias
+              - kms:GetPublicKey
+              - kms:PutKeyPolicy
+              - kms:Verify
+              - kms:GenerateDataKey
+              - kms:CreateGrant
+              - kms:ListKeys
+              - kms:ListGrants
+              - kms:DeleteImportedKeyMaterial
             Resource: '*'
       Tags:
         - Key: Name

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -234,7 +234,7 @@ Resources:
       Parameters:
         # The following are recommended to assist security scanning.
         log_statement: "ddl"
-        log_min_duration_statement: 15000
+        log_min_duration_statement: "15000"
 
   DB:
     Type: AWS::RDS::DBInstance

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -167,56 +167,56 @@ Resources:
               AWS:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
             Action:
-              - kms:GetKeyPolicy
-              - kms:UpdateKeyDescription
+              - kms:CancelKeyDeletion
+              - kms:ConnectCustomKeyStore
+              - kms:CreateAlias
+              - kms:CreateCustomKeyStore
+              - kms:CreateGrant
+              - kms:CreateKey
               - kms:Decrypt
+              - kms:DeleteAlias
+              - kms:DeleteCustomKeyStore
+              - kms:DeleteImportedKeyMaterial
+              - kms:DescribeCustomKeyStores
+              - kms:DescribeKey
+              - kms:DisableKey
+              - kms:DisableKeyRotation
+              - kms:DisconnectCustomKeyStore
               - kms:EnableKey
               - kms:EnableKeyRotation
-              - kms:GenerateDataKeyPair
-              - kms:DescribeKey
-              - kms:ReEncryptFrom
-              - kms:DeleteAlias
-              - kms:ImportKeyMaterial
-              - kms:CancelKeyDeletion
-              - kms:DisconnectCustomKeyStore
-              - kms:DeleteCustomKeyStore
-              - kms:ListKeyPolicies
-              - kms:ListResourceTags
-              - kms:GenerateDataKeyWithoutPlaintext
-              - kms:CreateCustomKeyStore
-              - kms:GetParametersForImport
-              - kms:ListAliases
-              - kms:ListRetirableGrants
-              - kms:GenerateRandom
               - kms:Encrypt
-              - kms:DisableKeyRotation
-              - kms:UpdateCustomKeyStore
-              - kms:RetireGrant
-              - kms:ReEncryptTo
-              - kms:UpdatePrimaryRegion
+              - kms:GenerateDataKey
+              - kms:GenerateDataKeyPair
               - kms:GenerateDataKeyPairWithoutPlaintext
-              - kms:ReplicateKey
+              - kms:GenerateDataKeyWithoutPlaintext
+              - kms:GenerateRandom
+              - kms:GetKeyPolicy
               - kms:GetKeyRotationStatus
+              - kms:GetParametersForImport
+              - kms:GetPublicKey
+              - kms:ImportKeyMaterial
+              - kms:ListAliases
+              - kms:ListGrants
+              - kms:ListKeyPolicies
+              - kms:ListKeys
+              - kms:ListResourceTags
+              - kms:ListRetirableGrants
+              - kms:PutKeyPolicy
+              - kms:ReEncryptFrom
+              - kms:ReEncryptTo
+              - kms:ReplicateKey
+              - kms:RetireGrant
+              - kms:RevokeGrant
+              - kms:ScheduleKeyDeletion
+              - kms:Sign
+              - kms:SynchronizeMultiRegionKey
               - kms:TagResource
               - kms:UntagResource
-              - kms:RevokeGrant
-              - kms:CreateKey
-              - kms:SynchronizeMultiRegionKey
-              - kms:ScheduleKeyDeletion
               - kms:UpdateAlias
-              - kms:Sign
-              - kms:DescribeCustomKeyStores
-              - kms:ConnectCustomKeyStore
-              - kms:DisableKey
-              - kms:CreateAlias
-              - kms:GetPublicKey
-              - kms:PutKeyPolicy
+              - kms:UpdateCustomKeyStore
+              - kms:UpdateKeyDescription
+              - kms:UpdatePrimaryRegion
               - kms:Verify
-              - kms:GenerateDataKey
-              - kms:CreateGrant
-              - kms:ListKeys
-              - kms:ListGrants
-              - kms:DeleteImportedKeyMaterial
             Resource: '*'
       Tags:
         - Key: Name

--- a/templates/quickstart-vpc-for-atlassian-services.yaml
+++ b/templates/quickstart-vpc-for-atlassian-services.yaml
@@ -71,7 +71,7 @@ Parameters:
       Quickstarts.
     Type: String
   KeyPairName:
-    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host.
     Type: String
     Default: ''
   BastionHostRequired:
@@ -79,7 +79,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Whether to provision a Bastion host instance; if 'true', then you need to provide an EC2 Key Pair
+    Description: Whether to provision a Bastion host instance; if 'true', then you need to provide an EC2 Key Pair.
     Type: String
   PrivateSubnet1CIDR:
     Default: 10.0.0.0/19
@@ -94,12 +94,12 @@ Parameters:
   PublicSubnet1CIDR:
     Default: 10.0.128.0/20
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR Block for the public DMZ subnet 1 located in Availability Zone 1
+    Description: CIDR Block for the public DMZ subnet 1 located in Availability Zone 1.
     Type: String
   PublicSubnet2CIDR:
     Default: 10.0.144.0/20
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR Block for the public DMZ subnet 2 located in Availability Zone 2
+    Description: CIDR Block for the public DMZ subnet 2 located in Availability Zone 2.
     Type: String
   QSS3BucketName:
     Default: 'aws-quickstart'
@@ -127,7 +127,7 @@ Parameters:
   VPCCIDR:
     Default: 10.0.0.0/16
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR Block for the VPC
+    Description: CIDR Block for the VPC.
     Type: String
 
 Conditions:


### PR DESCRIPTION
Some exclusions were added.
  

- E9101: "master" may be interpreted as a biased term. Consider a more inclusive alternative, such as "primary", "main", or "leader"
- W9006: Parameter Group name contains spelling error(s)
-   W9006: Parameter Group name is not sentence case
-   W9006: Parameter Label is not sentence case
-   W9006: Parameter Label contains spelling error(s)
-   W9002: Parameter is missing ParameterLabel
-   W9003: Parameter is not in a ParameterGroup
-   ERDSDBInstancePubliclyAccessible: AWS::RDS::DBInstance must have PubliclyAccessible configured False
-   EIAMPolicyWildcardResource: IAM policy should not allow * resource; This method in this in this policy support granular permissions
-   ERDSStorageEncryptionEnabled AWS::RDS::DBCluster must have StorageEncryption enabled