### PR TITLE
DCD-1389: Allow DB Major Upgrade

### DIFF
--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -278,6 +278,7 @@ Parameters:
       - true
       - false
     ConstraintDescription: Must be 'true' or 'false'.
+    Description: Allow major database version upgrade.
     Type: String
   DBMajorVersionUpgradeSwtich:
     Default: Green

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -208,10 +208,6 @@ Parameters:
     Type: String
     Default: 11.9
     AllowedValues:
-      - 9.6.16
-      - 9.6.17
-      - 9.6.18
-      - 9.6.19
       - 10.11
       - 10.12
       - 10.13

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -31,6 +31,7 @@ Metadata:
       - DBAllocatedStorageEncrypted
       - DBExportLogToCloudwatch
       - DBAllowMajorVersionUpgrade
+      - DBMajorVersionUpgradeSwtich
       - EnableEventSubscription
       - NotificationList
     - Label:
@@ -67,6 +68,8 @@ Metadata:
         default: Database connection CIDR
       DBAllowMajorVersionUpgrade:
         default: Allow major database version upgrade
+      DBMajorVersionUpgradeSwtich:
+        default: DB Major version upgrade switch,
       DBMultiAZ:
         default: Multi-AZ deployment
       Subnet1ID:
@@ -148,6 +151,9 @@ Conditions:
     !Equals
     - !Ref CustomDBSecurityGroup
     - ''
+  BlueDeployment: !Equals [!Ref DBMajorVersionUpgradeSwtich, "Blue"]
+  GreenDeployment: !Equals [!Ref DBMajorVersionUpgradeSwtich, "Green"]
+
 Outputs:
   DBName: 
     Description: "Amazon Aurora database name"
@@ -272,6 +278,14 @@ Parameters:
       - true
       - false
     ConstraintDescription: Must be 'true' or 'false'.
+    Type: String
+  DBMajorVersionUpgradeSwtich:
+    Default: Green
+    AllowedValues:
+      - Green
+      - Blue
+    ConstraintDescription: Must be 'Green' or 'Blue'.
+    Description: When updaing DB engine version, switch this value to 'Green' if 'Blue', 'Blue' if 'Green'. 
     Type: String
   CustomDBSecurityGroup:
     Description: "ID of the security group (e.g., sg-0234se). One will be created for you if left empty."
@@ -434,7 +448,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      DBParameterGroupName: !Ref DBParamGroup
+      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -468,7 +482,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      DBParameterGroupName: !Ref DBParamGroup
+      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -502,7 +516,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      DBParameterGroupName: !Ref DBParamGroup
+      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -528,8 +542,9 @@ Resources:
           Value: !Ref Compliance
     Type: "AWS::RDS::DBInstance"
 
-  DBParamGroup:
+  DBParamGroupGreen:
     Type: AWS::RDS::DBParameterGroup
+    Condition: GreenDeployment
     Properties:
       Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
       Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
@@ -539,9 +554,21 @@ Resources:
         # The following are recommended to assist security scanning.
         log_statement: "ddl"
         log_min_duration_statement: "15000"
-
-  RDSDBClusterParameterGroup:
+  DBParamGroupBlue:
+    Type: AWS::RDS::DBParameterGroup
+    Condition: BlueDeployment
+    Properties:
+      Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
+      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
+      Parameters:
+        log_rotation_age: '1440'
+        log_rotation_size: '102400'
+        # The following are recommended to assist security scanning.
+        log_statement: "ddl"
+        log_min_duration_statement: "15000"
+  RDSDBClusterParameterGroupGreen:
     Type: AWS::RDS::DBClusterParameterGroup
+    Condition: GreenDeployment
     Properties:
       Description: !Join [ "- ", [ "Aurora PG Cluster Parameter Group for  Cloudformation Stack ", !Ref DBName ] ]
       Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
@@ -550,12 +577,22 @@ Resources:
         # The following are recommended to assist security scanning.
         log_statement: "ddl"
         log_min_duration_statement: 15000
-
+  RDSDBClusterParameterGroupBlue:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Condition: BlueDeployment
+    Properties:
+      Description: !Join [ "- ", [ "Aurora PG Cluster Parameter Group for  Cloudformation Stack ", !Ref DBName ] ]
+      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
+      Parameters:
+        rds.force_ssl: 0
+        # The following are recommended to assist security scanning.
+        log_statement: "ddl"
+        log_min_duration_statement: 15000
   AuroraDBCluster:
     Type: "AWS::RDS::DBCluster"
     Properties:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
-      DBClusterParameterGroupName: !Ref RDSDBClusterParameterGroup
+      DBClusterParameterGroupName: !If [GreenDeployment, !Ref RDSDBClusterParameterGroupGreen, !Ref RDSDBClusterParameterGroupBlue]
       DBSubnetGroupName: !Ref AuroraDBSubnetGroup
       EnableCloudwatchLogsExports: 
         - !If [EnableDBLogExport, postgresql, !Ref 'AWS::NoValue']
@@ -860,6 +897,6 @@ Resources:
       - "configuration change"
       SnsTopicArn: !Ref DBSNSTopic
       SourceIds:
-      - !Ref DBParamGroup
+      - !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       SourceType: 'db-parameter-group'
   

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -448,7 +448,6 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      # DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -482,7 +481,6 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      # DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -516,7 +514,6 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      # DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -541,31 +538,6 @@ Resources:
           Key: Compliance
           Value: !Ref Compliance
     Type: "AWS::RDS::DBInstance"
-
-  # DBParamGroupGreen:
-  #   Type: AWS::RDS::DBParameterGroup
-  #   Condition: GreenDeployment
-  #   Properties:
-  #     Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
-  #     Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
-  #     Parameters:
-  #       log_rotation_age: '1440'
-  #       log_rotation_size: '102400'
-  #       # The following are recommended to assist security scanning.
-  #       log_statement: "ddl"
-  #       log_min_duration_statement: "15000"
-  # DBParamGroupBlue:
-  #   Type: AWS::RDS::DBParameterGroup
-  #   Condition: BlueDeployment
-  #   Properties:
-  #     Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
-  #     Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
-  #     Parameters:
-  #       log_rotation_age: '1440'
-  #       log_rotation_size: '102400'
-  #       # The following are recommended to assist security scanning.
-  #       log_statement: "ddl"
-  #       log_min_duration_statement: "15000"
   RDSDBClusterParameterGroupGreen:
     Type: AWS::RDS::DBClusterParameterGroup
     Condition: GreenDeployment
@@ -889,14 +861,4 @@ Resources:
       - !If [IsDBMultiAZ, !Ref AuroraDB2, !Ref "AWS::NoValue"]
       - !If [IsDBMultiAZ, !Ref AuroraDB3, !Ref "AWS::NoValue"]
       SourceType: 'db-instance'
-  # DBParameterGroupEventSubscription:
-  #   Condition: EventSubscription
-  #   Type: 'AWS::RDS::EventSubscription'
-  #   Properties:
-  #     EventCategories:
-  #     - "configuration change"
-  #     SnsTopicArn: !Ref DBSNSTopic
-  #     SourceIds:
-  #     - !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
-  #     SourceType: 'db-parameter-group'
   

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -30,6 +30,7 @@ Metadata:
       - DBMultiAZ
       - DBAllocatedStorageEncrypted
       - DBExportLogToCloudwatch
+      - DBAllowMajorVersionUpgrade
       - EnableEventSubscription
       - NotificationList
     - Label:
@@ -64,6 +65,8 @@ Metadata:
         default: Database port
       DBAccessCIDR:
         default: Database connection CIDR
+      DBAllowMajorVersionUpgrade:
+        default: Allow major database version upgrade
       DBMultiAZ:
         default: Multi-AZ deployment
       Subnet1ID:
@@ -263,6 +266,13 @@ Parameters:
     MinLength: "0"
     Default: 'AuroraPostgresDB'
     Type: String
+  DBAllowMajorVersionUpgrade:
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
+    Type: String
   CustomDBSecurityGroup:
     Description: "ID of the security group (e.g., sg-0234se). One will be created for you if left empty."
     Type: String
@@ -418,6 +428,7 @@ Resources:
       TargetKeyId: !Ref EncryptionKey
   AuroraDB1:
     Properties:
+      AllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
       AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
       DBClusterIdentifier: !Ref AuroraDBCluster
       DBInstanceClass: !Ref DBInstanceClass
@@ -451,6 +462,7 @@ Resources:
   AuroraDB2:
     Condition: IsDBMultiAZ
     Properties:
+      AllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
       AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
       DBClusterIdentifier: !Ref AuroraDBCluster
       DBInstanceClass: !Ref DBInstanceClass
@@ -484,6 +496,7 @@ Resources:
   AuroraDB3:
     Condition: IsDBMultiAZ
     Properties:
+      AllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
       AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
       DBClusterIdentifier: !Ref AuroraDBCluster
       DBInstanceClass: !Ref DBInstanceClass

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -545,6 +545,8 @@ Resources:
       Description: !Join [ "- ", [ "Aurora PG Cluster Parameter Group for  Cloudformation Stack ", !Ref DBName ] ]
       Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
       Parameters:
+        log_rotation_age: '1440'
+        log_rotation_size: '102400'
         rds.force_ssl: 0
         # The following are recommended to assist security scanning.
         log_statement: "ddl"
@@ -556,6 +558,8 @@ Resources:
       Description: !Join [ "- ", [ "Aurora PG Cluster Parameter Group for  Cloudformation Stack ", !Ref DBName ] ]
       Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
       Parameters:
+        log_rotation_age: '1440'
+        log_rotation_size: '102400'
         rds.force_ssl: 0
         # The following are recommended to assist security scanning.
         log_statement: "ddl"

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -448,7 +448,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
+      # DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -482,7 +482,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
+      # DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -516,7 +516,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
-      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
+      # DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       PubliclyAccessible: false
       Tags:
         -
@@ -542,30 +542,30 @@ Resources:
           Value: !Ref Compliance
     Type: "AWS::RDS::DBInstance"
 
-  DBParamGroupGreen:
-    Type: AWS::RDS::DBParameterGroup
-    Condition: GreenDeployment
-    Properties:
-      Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
-      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
-      Parameters:
-        log_rotation_age: '1440'
-        log_rotation_size: '102400'
-        # The following are recommended to assist security scanning.
-        log_statement: "ddl"
-        log_min_duration_statement: "15000"
-  DBParamGroupBlue:
-    Type: AWS::RDS::DBParameterGroup
-    Condition: BlueDeployment
-    Properties:
-      Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
-      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
-      Parameters:
-        log_rotation_age: '1440'
-        log_rotation_size: '102400'
-        # The following are recommended to assist security scanning.
-        log_statement: "ddl"
-        log_min_duration_statement: "15000"
+  # DBParamGroupGreen:
+  #   Type: AWS::RDS::DBParameterGroup
+  #   Condition: GreenDeployment
+  #   Properties:
+  #     Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
+  #     Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
+  #     Parameters:
+  #       log_rotation_age: '1440'
+  #       log_rotation_size: '102400'
+  #       # The following are recommended to assist security scanning.
+  #       log_statement: "ddl"
+  #       log_min_duration_statement: "15000"
+  # DBParamGroupBlue:
+  #   Type: AWS::RDS::DBParameterGroup
+  #   Condition: BlueDeployment
+  #   Properties:
+  #     Description: !Join [ "- ", [ "Aurora PG Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
+  #     Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"]
+  #     Parameters:
+  #       log_rotation_age: '1440'
+  #       log_rotation_size: '102400'
+  #       # The following are recommended to assist security scanning.
+  #       log_statement: "ddl"
+  #       log_min_duration_statement: "15000"
   RDSDBClusterParameterGroupGreen:
     Type: AWS::RDS::DBClusterParameterGroup
     Condition: GreenDeployment
@@ -889,14 +889,14 @@ Resources:
       - !If [IsDBMultiAZ, !Ref AuroraDB2, !Ref "AWS::NoValue"]
       - !If [IsDBMultiAZ, !Ref AuroraDB3, !Ref "AWS::NoValue"]
       SourceType: 'db-instance'
-  DBParameterGroupEventSubscription:
-    Condition: EventSubscription
-    Type: 'AWS::RDS::EventSubscription'
-    Properties:
-      EventCategories:
-      - "configuration change"
-      SnsTopicArn: !Ref DBSNSTopic
-      SourceIds:
-      - !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
-      SourceType: 'db-parameter-group'
+  # DBParameterGroupEventSubscription:
+  #   Condition: EventSubscription
+  #   Type: 'AWS::RDS::EventSubscription'
+  #   Properties:
+  #     EventCategories:
+  #     - "configuration change"
+  #     SnsTopicArn: !Ref DBSNSTopic
+  #     SourceIds:
+  #     - !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
+  #     SourceType: 'db-parameter-group'
   

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -121,6 +121,13 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type. Not used for Amazon Aurora.
     Type: String
+  DBAllowMajorVersionUpgrade:
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
+    Type: String
   QSS3BucketName:
     Default: 'aws-quickstart'
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
@@ -206,6 +213,7 @@ Resources:
         DBMultiAZ: !Ref DBMultiAZ
         DBName: ''
         DBPort: '5432'
+        DBAllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
         EnableEventSubscription: 'false'
         Subnet1ID: !Select
           - 0
@@ -253,6 +261,7 @@ Resources:
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
         DBStorageType: !Ref DBStorageType
+        DBAllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
         Subnet1ID: !Select
           - 0
           - !Split

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -127,6 +127,7 @@ Parameters:
       - true
       - false
     ConstraintDescription: Must be 'true' or 'false'.
+    Description: Allow major database version upgrade.
     Type: String
   DBMajorVersionUpgradeSwtich:
     Default: Green

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -16,9 +16,8 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9
+    Default: 10
     AllowedValues:
-      - 9
       - 10
       - 11
       - 12

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -129,12 +129,12 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBMajorVersionUpgradeSwtich:
-    Default: "Green"
+    Default: Green
     AllowedValues:
-      - "Green"
-      - "Blue"
+      - Green
+      - Blue
     ConstraintDescription: Must be 'Green' or 'Blue'.
-    Description: When updaing DB engine version, update this value to Green if Blue, Blue if Green.
+    Description: When updaing DB engine version, update this value to 'Green' if 'Blue', 'Blue' if 'Green'.
     Type: String
   QSS3BucketName:
     Default: 'aws-quickstart'

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -134,7 +134,8 @@ Parameters:
       - "Green"
       - "Blue"
     ConstraintDescription: Must be 'Green' or 'Blue'.
-    Description: When updaing DB engine version, update this value to Green if Blue, Blue if Green. 
+    Description: When updaing DB engine version, update this value to Green if Blue, Blue if Green.
+    Type: String
   QSS3BucketName:
     Default: 'aws-quickstart'
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -222,6 +222,7 @@ Resources:
         DBName: ''
         DBPort: '5432'
         DBAllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
+        DBMajorVersionUpgradeSwtich: !Ref DBMajorVersionUpgradeSwtich
         EnableEventSubscription: 'false'
         Subnet1ID: !Select
           - 0

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -269,6 +269,7 @@ Resources:
         DBMultiAZ: !Ref DBMultiAZ
         DBStorageType: !Ref DBStorageType
         DBAllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
+        DBMajorVersionUpgradeSwtich: !Ref DBMajorVersionUpgradeSwtich
         Subnet1ID: !Select
           - 0
           - !Split

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -128,6 +128,13 @@ Parameters:
       - false
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
+  DBMajorVersionUpgradeSwtich:
+    Default: "Green"
+    AllowedValues:
+      - "Green"
+      - "Blue"
+    ConstraintDescription: Must be 'Green' or 'Blue'.
+    Description: When updaing DB engine version, update this value to Green if Blue, Blue if Green. 
   QSS3BucketName:
     Default: 'aws-quickstart'
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -23,9 +23,8 @@ Metadata:
     Exclusions: [W4002, E3012, E1001, E9101, W9006, W9002, W9003, ERDSDBInstancePubliclyAccessible, EIAMPolicyWildcardResource, ERDSStorageEncryptionEnabled]
 Parameters:
   DBEngineVersion:
-    Default: 9.6
+    Default: 10
     AllowedValues:
-      - 9.6
       - 10
       - 11
       - 12

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -141,12 +141,12 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBMajorVersionUpgradeSwtich:
-    Default: "Green"
+    Default: Green
     AllowedValues:
-      - "Green"
-      - "Blue"
+      - Green
+      - Blue
     ConstraintDescription: Must be 'Green' or 'Blue'.
-    Description: When updaing DB engine version, switch this value to Green if Blue, Blue if Green. 
+    Description: When updaing DB engine version, switch this value to 'Green' if 'Blue', 'Blue' if 'Green'. 
     Type: String
   CustomDBSecurityGroup:
     Description: The security group to apply to the database

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -140,6 +140,14 @@ Parameters:
       - false
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
+  DBMajorVersionUpgradeSwtich:
+    Default: "Green"
+    AllowedValues:
+      - "Green"
+      - "Blue"
+    ConstraintDescription: Must be 'Green' or 'Blue'.
+    Description: When updaing DB engine version, switch this value to Green if Blue, Blue if Green. 
+    Type: String
   CustomDBSecurityGroup:
     Description: The security group to apply to the database
     Type: AWS::EC2::SecurityGroup::Id
@@ -155,6 +163,8 @@ Conditions:
     !Equals [!Ref DBStorageType, io1]
   UseDatabaseEncryption:
     !Equals [!Ref DBAllocatedStorageEncrypted, true]
+  BlueDeployment: !Equals [!Ref MajorVersionUpgrade, "Blue"]
+  GreenDeployment: !Equals [!Ref MajorVersionUpgrade, "Green"]
 
 Resources:
   DBSubnetGroup: 
@@ -288,8 +298,19 @@ Resources:
             - logs:PutLogEvents
             Resource: !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*"
 
-  DBParamGroup:
+  DBParamGroupGreen:
     Type: AWS::RDS::DBParameterGroup
+    Condition: GreenDeployment
+    Properties:
+      Description: "DB Parameter Group for security error logging"
+      Family: !Join [ "", [ "postgres", !Ref DBEngineVersion ] ]
+      Parameters:
+        # The following are recommended to assist security scanning.
+        log_statement: "ddl"
+        log_min_duration_statement: "15000"
+  DBParamGroupBlue:
+    Type: AWS::RDS::DBParameterGroup
+    Condition: BlueDeployment
     Properties:
       Description: "DB Parameter Group for security error logging"
       Family: !Join [ "", [ "postgres", !Ref DBEngineVersion ] ]
@@ -307,7 +328,7 @@ Resources:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       DBInstanceClass: !Ref DBInstanceClass
       DBInstanceIdentifier: !GetAtt DbInstanceName.DBInstanceName
-      DBParameterGroupName: !Ref DBParamGroup
+      DBParameterGroupName: !If [GreenDeployment, !Ref DBParamGroupGreen, !Ref DBParamGroupBlue]
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: postgres
       EngineVersion: !Ref DBEngineVersion

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -139,6 +139,7 @@ Parameters:
       - true
       - false
     ConstraintDescription: Must be 'true' or 'false'.
+    Description: Allow major database version upgrade.
     Type: String
   DBMajorVersionUpgradeSwtich:
     Default: Green

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -163,8 +163,8 @@ Conditions:
     !Equals [!Ref DBStorageType, io1]
   UseDatabaseEncryption:
     !Equals [!Ref DBAllocatedStorageEncrypted, true]
-  BlueDeployment: !Equals [!Ref MajorVersionUpgrade, "Blue"]
-  GreenDeployment: !Equals [!Ref MajorVersionUpgrade, "Green"]
+  BlueDeployment: !Equals [!Ref DBMajorVersionUpgradeSwtich, "Blue"]
+  GreenDeployment: !Equals [!Ref DBMajorVersionUpgradeSwtich, "Green"]
 
 Resources:
   DBSubnetGroup: 

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -14,6 +14,8 @@
 # DBPort
 # DBAllocatedStorageEncrypted
 # DBStorageType
+# DBAllowMajorVersionUpgrade
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: RDS Postgres Database for use in Atlassian Standard Infrastructure (qs-1aj6s44e4)
 Metadata:
@@ -130,6 +132,13 @@ Parameters:
       - Provisioned IOPS
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type
+    Type: String
+  DBAllowMajorVersionUpgrade:
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   CustomDBSecurityGroup:
     Description: The security group to apply to the database
@@ -293,6 +302,7 @@ Resources:
     Type: AWS::RDS::DBInstance
     Properties:
       AllocatedStorage: !Ref DBAllocatedStorage
+      AllowMajorVersionUpgrade: !Ref DBAllowMajorVersionUpgrade
       AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       DBInstanceClass: !Ref DBInstanceClass


### PR DESCRIPTION
This is pr is to enable major db version update for Postgresql and Aurora db.
CF doesn't allow updating pre-existing db parameter group/cluster group so I followed [the blue/green method](https://stackoverflow.com/questions/68086201/how-to-do-a-major-version-upgrade-for-aurora-postgres-in-cloudformation-with-cus) to force create new group on version upgrade.

