### PR TITLE
DCD-1434: Removed version 9 from DBEngineVersion

### DIFF
--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -93,14 +93,6 @@ Metadata:
 
 Mappings:
   DBFamilyMap:
-    "9.6.16":
-      "family": "aurora-postgresql9.6"
-    "9.6.17":
-      "family": "aurora-postgresql9.6"
-    "9.6.18":
-      "family": "aurora-postgresql9.6"
-    "9.6.19":
-      "family": "aurora-postgresql9.6"
     "10.11":
       "family": "aurora-postgresql10"
     "10.12":
@@ -199,10 +191,6 @@ Parameters:
     Type: String
     Default: 11.9
     AllowedValues:
-      - 9.6.16
-      - 9.6.17
-      - 9.6.18
-      - 9.6.19
       - 10.11
       - 10.12
       - 10.13

--- a/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-aurora-postgres-for-atlassian-services.yaml
@@ -93,6 +93,14 @@ Metadata:
 
 Mappings:
   DBFamilyMap:
+    "9.6.16":
+      "family": "aurora-postgresql9.6"
+    "9.6.17":
+      "family": "aurora-postgresql9.6"
+    "9.6.18":
+      "family": "aurora-postgresql9.6"
+    "9.6.19":
+      "family": "aurora-postgresql9.6"
     "10.11":
       "family": "aurora-postgresql10"
     "10.12":
@@ -187,10 +195,14 @@ Parameters:
     Description: "The number of days for which automatic database snapshots are retained."
     Type: String
   DBEngineVersion:
-    Description: Select Database Engine Version
+    Description: "Select Database Engine Version. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
     Default: 11.9
     AllowedValues:
+      - 9.6.16
+      - 9.6.17
+      - 9.6.18
+      - 9.6.19
       - 10.11
       - 10.12
       - 10.13

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -18,10 +18,11 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
+      - 9
       - 10
       - 11
       - 12
-    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
+    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBSecurityGroup:
     Description: "ID of the security group (e.g. sg-0234se). One will be created for you if left empty."
@@ -169,10 +170,12 @@ Mappings:
   # https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html
   SemanticDBVersions:
     PostgreSQL:
+      "9": "9.6"
       "10": "10"
       "11": "11"
       "12": "12"
     AuroraPostgreSQL:
+      "9": "9.6.19"
       "10": "10.14"
       "11": "11.9"
       "12": "12.4"

--- a/templates/quickstart-database-for-atlassian-services.yaml
+++ b/templates/quickstart-database-for-atlassian-services.yaml
@@ -16,9 +16,8 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9
+    Default: 10
     AllowedValues:
-      - 9
       - 10
       - 11
       - 12
@@ -170,12 +169,10 @@ Mappings:
   # https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html
   SemanticDBVersions:
     PostgreSQL:
-      "9": "9.6"
       "10": "10"
       "11": "11"
       "12": "12"
     AuroraPostgreSQL:
-      "9": "9.6.19"
       "10": "10.14"
       "11": "11.9"
       "12": "12.4"

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -21,9 +21,8 @@ Metadata:
     Exclusions: [W4002, E3012, E1001, E9101, W9006, W9002, W9003, ERDSDBInstancePubliclyAccessible, EIAMPolicyWildcardResource, ERDSStorageEncryptionEnabled]
 Parameters:
   DBEngineVersion:
-    Default: 9.6
+    Default: 10
     AllowedValues:
-      - 9.6
       - 10
       - 11
       - 12

--- a/templates/quickstart-postgres-for-atlassian-services.yaml
+++ b/templates/quickstart-postgres-for-atlassian-services.yaml
@@ -23,10 +23,11 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
+      - 9.6
       - 10
       - 11
       - 12
-    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
+    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBAutoMinorVersionUpgrade:
     Default: true


### PR DESCRIPTION
Remove Postgres version 9 as the version will be EOL

