### PR TITLE
DCD-1333 Disable keypairs for Taskcat CI builds

### DIFF
--- a/ci/params/default/quickstart-asi-custom-export.json
+++ b/ci/params/default/quickstart-asi-custom-export.json
@@ -20,7 +20,7 @@
         "ParameterValue": "$[taskcat_random-string]"
     },
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
+        "ParameterKey": "BastionHostRequired",
+        "ParameterValue": "false"
     }
 ]

--- a/ci/params/with-bucket-region/quickstart-with-bucket-region.json
+++ b/ci/params/with-bucket-region/quickstart-with-bucket-region.json
@@ -24,7 +24,7 @@
         "ParameterValue": "$[taskcat_random-string]"
     },
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
+        "ParameterKey": "BastionHostRequired",
+        "ParameterValue": "false"
     }
 ]

--- a/ci/quickstart-vpc-for-atlassian-services-inputs.json
+++ b/ci/quickstart-vpc-for-atlassian-services-inputs.json
@@ -19,9 +19,8 @@
         "ParameterKey": "ExportPrefix",
         "ParameterValue": "$[taskcat_random-string]"
     },
-
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
+        "ParameterKey": "BastionHostRequired",
+        "ParameterValue": "false"
     }
 ]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -23,5 +23,5 @@ global:
 
 tests:
   atlassian-vpc:
-    parameter_input: quickstat-vpc-for-atlassian-services-inputs.json
+    parameter_input: quickstart-vpc-for-atlassian-services-inputs.json
     template_file: quickstart-vpc-for-atlassian-services.yaml


### PR DESCRIPTION
DCD-1333 Disable keypairs for Taskcat CI builds
Fixed mistake in name from "quickstart-vpc-for-atlassian-services-inputs.json" file